### PR TITLE
Keymap rgoulter ortho 5x12, 5x15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,18 @@ firmware-ch32x_48-rgoulter.hex: keymaps/ortho-4x12/keymap.ncl keyboards/ch32x-48
 	@echo Copying firmware artifact...
 	cp $(FIRMWARE_CH32X)/build/usb-device-compositekm.hex $@
 
+firmware-ch32x_75-rgoulter.hex: KEYMAP := keymaps/ortho-5x15/keymap.ncl
+firmware-ch32x_75-rgoulter.hex: BOARD := keyboards/ch32x-75.ncl
+firmware-ch32x_75-rgoulter.hex: keymaps/ortho-5x12/keymap.ncl
+firmware-ch32x_75-rgoulter.hex: keymaps/ortho-5x15/keymap.ncl
+firmware-ch32x_75-rgoulter.hex: keyboards/ch32x-75.ncl
+	@echo Building keymap in $(SMART_KEYMAP)...
+	(cd $(SMART_KEYMAP) && devenv shell just keymap=$(abspath $(CURDIR)/$(KEYMAP)) dest_dir=$(FIRMWARE_CH32X)/libsmartkeymap/ install)
+	@echo Building firmware in $(FIRMWARE_CH32X)...
+	(cd $(FIRMWARE_CH32X) && devenv shell just board=$(abspath $(CURDIR)/$(BOARD)) build)
+	@echo Copying firmware artifact...
+	cp $(FIRMWARE_CH32X)/build/usb-device-compositekm.hex $@
+
 target/thumbv6m-none-eabi/release/pico42: src/bin/pico42.rs keymaps/pico42/keymap.ncl
 	env \
 		SMART_KEYMAP_CUSTOM_KEYMAP="$(abspath $(CURDIR)/keymaps/pico42/keymap.ncl)" \

--- a/keyboards/ch32x-75.ncl
+++ b/keyboards/ch32x-75.ncl
@@ -1,0 +1,46 @@
+{
+  gpio_pins,
+
+  board = {
+    matrix =
+      let p = gpio_pins in
+      {
+        cols = [
+          # COL1 - COL5
+          p.B1,
+          p.B2,
+          p.B3,
+          p.B4,
+          p.B5,
+          # COL6 - COL10
+          p.B13,
+          p.A13,
+          p.A12,
+          p.A11,
+          p.A15,
+          # COL11 - COL15
+          p.A16,
+          p.A17,
+          p.A18,
+          p.A19,
+          p.A20,
+        ],
+        rows = [p.A8, p.A9, p.A4, p.A5, p.A6],
+        key_count = 75,
+        implementation = "col_to_row",
+      },
+
+    # The CH32X-75 a matrix of 5 rows x 15 columns.
+    #
+    # Want the keymap index to refer to keys row-wise.
+    keymap_index_for_key = fun { column_index | Number, row_index | Number, .. } =>
+      'Ok (row_index * 15 + column_index),
+
+    led = {
+      enabled = true,
+      pin = gpio_pins.B9,
+    },
+
+    debug.tx = 2,
+  },
+}

--- a/keymaps/ortho-5x12/keymap.ncl
+++ b/keymaps/ortho-5x12/keymap.ncl
@@ -1,0 +1,87 @@
+let K = import "keys.ncl" in
+
+let DVORAK_  = 0 in
+let GAMING_  = 1 in
+let RAISE_  = 2 in
+let LOWER_  = RAISE_ + 1 in
+let ADJUST_ = RAISE_ + 2 in
+
+{
+  chords =
+    let K = import "keys.ncl" in
+    [
+        { indices = [39, 40], key = K.LeftGUI & K.PageUp, },
+        { indices = [43, 44], key = K.LeftGUI & K.PageDown, },
+    ],
+
+  config.tap_hold.interrupt_response = "HoldOnKeyTap",
+
+  custom_keys = fun K =>
+    let HoldLayerMod = fun layer_index => K.hold (K.layer_mod.hold layer_index) in
+    {
+      DVOR = K.layer_mod.set_default DVORAK_,
+      GAME = K.layer_mod.set_default GAMING_,
+
+      ENT_R = K.Return & HoldLayerMod RAISE_,
+      ESC_L = K.Escape & HoldLayerMod LOWER_,
+      ADJ   = K.layer_mod.hold ADJUST_,
+
+      A_A = K.A & K.H_LAlt,
+      G_O = K.O & K.H_LGUI,
+      C_E = K.E & K.H_LCtrl,
+      S_U = K.U & K.H_LShift,
+
+      S_H = K.H & K.H_RShift,
+      C_T = K.T & K.H_LCtrl,
+      G_N = K.N & K.H_RGUI,
+      A_S = K.S & K.H_LAlt,
+
+      SK_S = K.sticky K.LeftShift,
+      SK_C = K.sticky K.LeftCtrl,
+      SK_G = K.sticky K.LeftGUI,
+      SK_A = K.sticky K.LeftAlt,
+    },
+
+  layers = [
+    # Base: Dvorak
+    m%"
+      `    1    2    3   4     5                  6    7     8    9    0    DEL
+      TAB  '    ,    .   P     Y                  F    G     C    R    L    BSPC
+      ESC  A_A  G_O  C_E S_U   I                  D    S_H   C_T  G_N  A_S  /
+      LSFT ;    Q    J   K     X                  B    M     W    V    Z    RSFT
+      LCTL LGUI LALT TAB ESC_L SPC                BSPC ENT_R DEL  RALT RGUI RCTL
+    "%,
+    # Base: Gaming
+    m%"
+      `    1    2    3   4     5                  6    7     8    9    0    DEL
+      TAB  Q    W    E   R     T                  Y    U     I    O    P    BSPC
+      ESC  A    S    D   F     G                  H    J     K    L    ;    '
+      LSFT Z    X    C   V     B                  N    M     ,    .    /    RSFT
+      LCTL LGUI LALT TAB ESC_L SPC                BSPC ENT_R DEL  RALT RGUI RCTL
+    "%,
+    # Raise
+    m%"
+      TTTT TTTT TTTT TTTT TTTT TTTT                TTTT TTTT TTTT TTTT TTTT TTTT
+      `    1    2    3    4    5                   6    7    8    9    0    \
+      DEL  F1   F2   F3   F4   F5                  F6   -    =    [    ]    /
+      TTTT F7   F8   F9   F10  F11                 F12  TTTT TTTT TTTT TTTT TTTT
+      TTTT TTTT TTTT TTTT ADJ  TTTT                TTTT TTTT TTTT TTTT TTTT TTTT
+    "%,
+    # Lower
+    m%"
+      TTTT TTTT TTTT TTTT TTTT TTTT                TTTT TTTT TTTT TTTT TTTT TTTT
+      ~    !    @    #    $    %                   ^    &    *    (    )    |
+      INS  F1   F2   F3   F4   F5                  F6   _    +    {    }    ?
+      TTTT F7   F8   F9   F10  F11                 F12  TTTT HOME PGDN PGUP END
+      TTTT TTTT TTTT TTTT TTTT TTTT                TTTT ADJ  LEFT DOWN UP   RGHT
+    "%,
+    # Adjust
+    m%"
+      DVOR GAME TTTT TTTT TTTT TTTT                TTTT TTTT TTTT TTTT TTTT TTTT
+      TTTT BOOT TTTT TTTT TTTT TTTT                TTTT PSCR SCRL PAUS TTTT TTTT
+      CAPS SK_A SK_G SK_C SK_S TTTT                TTTT SK_S SK_C SK_G SK_A CWTG
+      TTTT TTTT TTTT TTTT TTTT TTTT                TTTT TTTT TTTT TTTT TTTT TTTT
+      TTTT TTTT TTTT TTTT TTTT TTTT                TTTT TTTT TTTT TTTT TTTT TTTT
+    "%,
+  ],
+}

--- a/keymaps/ortho-5x15/keymap.ncl
+++ b/keymaps/ortho-5x15/keymap.ncl
@@ -1,0 +1,23 @@
+let remap_60keys = { source_key_count = 60 } & (import "layouts/remap.ncl") in
+
+let from_ortho_5x12 = fun
+  {
+    no_key = XXX,
+    from_layout = [
+      k00, k01, k02, k03, k04, k05,                k06, k07, k08, k09, k10, k11,
+      k12, k13, k14, k15, k16, k17,                k18, k19, k20, k21, k22, k23,
+      k24, k25, k26, k27, k28, k29,                k30, k31, k32, k33, k34, k35,
+      k36, k37, k38, k39, k40, k41,                k42, k43, k44, k45, k46, k47,
+      k48, k49, k50, k51, k52, k53,                k54, k55, k56, k57, k58, k59,
+    ]
+  } =>
+  [
+      k00, k01, k02, k03, k04, k05, XXX, XXX, XXX, k06, k07, k08, k09, k10, k11,
+      k12, k13, k14, k15, k16, k17, XXX, XXX, XXX, k18, k19, k20, k21, k22, k23,
+      k24, k25, k26, k27, k28, k29, XXX, XXX, XXX, k30, k31, k32, k33, k34, k35,
+      k36, k37, k38, k39, k40, k41, XXX, XXX, XXX, k42, k43, k44, k45, k46, k47,
+      k48, k49, k50, k51, k52, k53, XXX, XXX, XXX, k54, k55, k56, k57, k58, k59,
+  ]
+in
+(import "../ortho-5x12/keymap.ncl")
+  |> remap_60keys.into_layout from_ortho_5x12


### PR DESCRIPTION
Copy over ortho-5x12 and ortho-5x15 from smart-keymap.

Especially for the ch32x-75 keyboard.